### PR TITLE
fix: CLAUDE.md 建置指令改用 cp -n 避免覆寫本機 Secrets.xcconfig

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,8 @@ cd AgenticCLI && swift build -c release --arch arm64
 # 核心函式庫
 cd Packages/AgenticCore && swift build
 
-# 選單列應用程式（需先產生 Secrets.xcconfig）
-cd AgenticUsage && cp AgenticUsage/Configuration/Secrets.xcconfig.template AgenticUsage/Configuration/Secrets.xcconfig
+# 選單列應用程式（需先產生 Secrets.xcconfig，若已存在則跳過以免覆寫真實 secrets）
+cd AgenticUsage && cp -n AgenticUsage/Configuration/Secrets.xcconfig.template AgenticUsage/Configuration/Secrets.xcconfig
 cd AgenticUsage && xcodebuild build -project AgenticUsage.xcodeproj -scheme AgenticUsage -configuration Release
 ```
 


### PR DESCRIPTION
- cp → cp -n（no-clobber），Secrets.xcconfig 已存在時不覆寫，防止 Claude Code session 執行建置指令時把真實 secrets 蓋成 template 內容

https://claude.ai/code/session_01GAHQNVuPQ2JxtZ8skm1MAf